### PR TITLE
Fix claude-code.nvim plugin configuration format

### DIFF
--- a/.devcontainer/base-config/nvim/lua/plugins/claude-code.lua
+++ b/.devcontainer/base-config/nvim/lua/plugins/claude-code.lua
@@ -16,13 +16,23 @@ return {
 
       -- Keymaps
       keymaps = {
-        toggle = "<C-,>",  -- Toggle Claude Code terminal
-        continue = "<leader>cC",  -- Continue conversation
-        verbose = "<leader>cV",  -- Verbose mode
+        toggle = {
+          normal = "<C-,>",  -- Toggle Claude Code terminal in normal mode
+        },
+        continue = {
+          normal = "<leader>cC",  -- Continue conversation in normal mode
+        },
+        verbose = {
+          normal = "<leader>cV",  -- Verbose mode in normal mode
+        },
       },
 
       -- Shell configuration
-      shell = vim.o.shell,
+      shell = {
+        cmd = vim.o.shell,
+        args = { "-c" },
+        separator = ";",
+      },
 
       -- Command configuration
       command = "claude-code",


### PR DESCRIPTION
## Summary
- Fixed claude-code.nvim plugin configuration to use correct table formats
- Resolved "shell config must be a table" error when starting nvim
- Updated keymaps to use mode-specific mappings structure

## Changes
- Shell configuration now uses table with `cmd`, `args`, and `separator` fields
- Keymaps updated to use tables with `normal` mode specifications
- Configuration structure now matches plugin requirements

## Test plan
- [x] Start nvim without errors
- [x] Verify claude-code.nvim plugin loads correctly
- [x] Test keybindings work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)