### PR TITLE
Fix dotfiles environment variable loading in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,8 @@
 {
   "name": "Neovim Full-Stack Development",
-  "build": {
-    "dockerfile": "Dockerfile",
-    "context": "."
-  },
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "neovim-dev",
+  "workspaceFolder": "/workspace",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": "latest"


### PR DESCRIPTION
## Summary
Fix dotfiles environment variable loading by switching from direct Dockerfile build to docker-compose configuration.

## Problem
The current devcontainer.json uses a direct Dockerfile build which bypasses the docker-compose.yml configuration. This prevents the `.env` file from being loaded, so `DOTFILES_REPO` and `DOTFILES_INSTALL_CMD` environment variables are not available to the `post-create.sh` script.

## Solution
- Replace `build.dockerfile` configuration with `dockerComposeFile` reference
- Set service to `neovim-dev` to match the service name in docker-compose.yml
- Maintain `workspaceFolder` setting for proper workspace mounting

## Changes
```diff
- "build": {
-   "dockerfile": "Dockerfile",
-   "context": "."
- },
+ "dockerComposeFile": "../docker-compose.yml",
+ "service": "neovim-dev",
+ "workspaceFolder": "/workspace",
```

## Benefits
- ✅ Automatic dotfiles cloning and installation during container creation
- ✅ All environment variables from `.env` file are properly loaded
- ✅ Leverages existing docker-compose.yml infrastructure
- ✅ Maintains compatibility with all existing features

## Test Plan
- [x] Verify devcontainer.json syntax is valid
- [x] Confirm service name matches docker-compose.yml
- [x] Ensure docker-compose.yml has `env_file: - .env` configuration
- [ ] Test container rebuild with dotfiles auto-installation

🤖 Generated with [Claude Code](https://claude.ai/code)